### PR TITLE
Fixed the MonadFail compilation error

### DIFF
--- a/src/Database/XBase/Dbf/Structures.hs
+++ b/src/Database/XBase/Dbf/Structures.hs
@@ -58,7 +58,7 @@ data DbfFieldDescriptor = DbfFieldDescriptor
 dbfRecLengthForFields fields = 1 + sum (map dbfFieldLength fields)
 
 putDbfFieldName bs 
-    | len > maxLen  = fail ("putDbfFieldName: Field name too long (" ++ show len ++ " bytes)")
+    | len > maxLen  = error ("putDbfFieldName: Field name too long (" ++ show len ++ " bytes)")
     | otherwise = do
         putLazyByteString bs
         putLazyByteString (BS.replicate (maxLen-len) 0)
@@ -217,4 +217,4 @@ getDbfFile = do
     hdr <- getDbfFileHeader
     recs <- unfoldM (getDbfRecord (fromIntegral (dbfFileRecLength hdr)))
     return (hdr, recs)
-    
+


### PR DESCRIPTION
A one-line fix to enable compilation with newer `base` versions. The error was

```
src/Database/XBase/Dbf/Structures.hs:61:23: error: [GHC-39999]
    • No instance for ‘MonadFail PutM’ arising from a use of ‘fail’
    • In the expression:
        fail
          ("putDbfFieldName: Field name too long (" ++ show len ++ " bytes)")
```